### PR TITLE
Automatic db updating

### DIFF
--- a/SalesMap/Main.cs
+++ b/SalesMap/Main.cs
@@ -29,10 +29,10 @@ namespace SalesMap
         {
             InitializeComponent();
 
-            readFiles();
-
             if (Properties.Settings.Default.AutoCheckUpdate)
             {
+                compareFiles();
+
                 WebClient client = new WebClient();
                 string url = "https://github.com/derekantrican/SalesMap/releases";
                 string html = "";
@@ -57,6 +57,74 @@ namespace SalesMap
                         System.Diagnostics.Process.Start(url);
                     }
                 }
+            }
+
+            readFiles();
+        }
+
+        public void compareFiles()
+        {
+            string regionPath = @"C:\Users\" + Environment.UserName + @"\Regions.txt";
+            string salesPath = @"C:\Users\" + Environment.UserName + @"\SalesReps.txt";
+
+            string regionText = "";
+            string salesText = "";
+
+            WebClient client = new WebClient();
+            string url = "https://github.com/derekantrican/SalesMap/wiki/Most-current-%22databases%22-and-install-instructions";
+            string html = "";
+
+            string regionTextOnline = "";
+            string salesTextOnline = "";
+
+            try
+            {
+                html = client.DownloadString(url);
+
+                regionTextOnline = html.Substring(html.IndexOf("<pre><code>") + 11).Split('<')[0];
+                salesTextOnline = html.Substring(html.LastIndexOf("<pre><code>") + 11).Split('<')[0];
+            }
+            catch
+            {
+                return;
+            }
+
+            if (File.Exists(regionPath))
+            {
+                regionText = File.ReadAllText(regionPath);
+            }
+            else
+            {
+                using (StreamReader reader = new StreamReader(Assembly.GetExecutingAssembly().GetManifestResourceStream("SalesMap.Regions.txt")))
+                {
+                    regionText = reader.ReadToEnd();
+                }
+            }
+
+            if (File.Exists(salesPath))
+            {
+                salesText = File.ReadAllText(salesPath);
+            }
+            else
+            {
+                using (StreamReader reader = new StreamReader(Assembly.GetExecutingAssembly().GetManifestResourceStream("SalesMap.SalesReps.txt")))
+                {
+                    salesText = reader.ReadToEnd();
+                }
+            }
+
+            //Remove the extra character that comes at the end of these strings
+            regionTextOnline = regionTextOnline.TrimEnd(regionTextOnline[regionTextOnline.Length - 1]);
+            salesTextOnline = salesTextOnline.TrimEnd(salesTextOnline[salesTextOnline.Length - 1]);
+
+            if (regionText != regionTextOnline)
+            {
+                File.WriteAllText(regionPath, regionTextOnline);
+            }
+
+            if (salesText != salesTextOnline)
+            {
+                File.WriteAllText(salesPath, salesTextOnline);
             }
         }
 

--- a/SalesMap/Main.cs
+++ b/SalesMap/Main.cs
@@ -458,8 +458,6 @@ namespace SalesMap
             subject = mailtoFormat(subject, rep, cc, phone);
             body = mailtoFormat(body, rep, cc, phone);
 
-            Console.WriteLine(body);
-
             System.Diagnostics.Process proc = new System.Diagnostics.Process();
             proc.StartInfo.FileName = "mailto:?cc=" + cc + "&subject=" + subject + "&body=" + body;
             proc.Start();

--- a/SalesMap/Settings.Designer.cs
+++ b/SalesMap/Settings.Designer.cs
@@ -30,14 +30,12 @@
         {
             this.labelMapLocation = new System.Windows.Forms.Label();
             this.textBoxMapLocation = new System.Windows.Forms.TextBox();
-            this.buttonRegions = new System.Windows.Forms.Button();
-            this.buttonSalesReps = new System.Windows.Forms.Button();
             this.buttonSave = new System.Windows.Forms.Button();
             this.linkLabelGitHub = new System.Windows.Forms.LinkLabel();
             this.textBoxEdit = new System.Windows.Forms.RichTextBox();
             this.linkLabelUpdate = new System.Windows.Forms.LinkLabel();
-            this.buttonOffSMR = new System.Windows.Forms.Button();
             this.checkBoxAutoUpdates = new System.Windows.Forms.CheckBox();
+            this.labelOffSMR = new System.Windows.Forms.Label();
             this.SuspendLayout();
             // 
             // labelMapLocation
@@ -55,26 +53,6 @@
             this.textBoxMapLocation.Name = "textBoxMapLocation";
             this.textBoxMapLocation.Size = new System.Drawing.Size(273, 20);
             this.textBoxMapLocation.TabIndex = 2;
-            // 
-            // buttonRegions
-            // 
-            this.buttonRegions.Location = new System.Drawing.Point(12, 40);
-            this.buttonRegions.Name = "buttonRegions";
-            this.buttonRegions.Size = new System.Drawing.Size(75, 23);
-            this.buttonRegions.TabIndex = 3;
-            this.buttonRegions.Text = "Edit Regions";
-            this.buttonRegions.UseVisualStyleBackColor = true;
-            this.buttonRegions.Click += new System.EventHandler(this.buttonRegions_Click);
-            // 
-            // buttonSalesReps
-            // 
-            this.buttonSalesReps.Location = new System.Drawing.Point(87, 40);
-            this.buttonSalesReps.Name = "buttonSalesReps";
-            this.buttonSalesReps.Size = new System.Drawing.Size(92, 23);
-            this.buttonSalesReps.TabIndex = 4;
-            this.buttonSalesReps.Text = "Edit Sales Reps";
-            this.buttonSalesReps.UseVisualStyleBackColor = true;
-            this.buttonSalesReps.Click += new System.EventHandler(this.buttonSalesReps_Click);
             // 
             // buttonSave
             // 
@@ -117,16 +95,6 @@
             this.linkLabelUpdate.Text = "Check for Update";
             this.linkLabelUpdate.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkLabelUpdate_LinkClicked);
             // 
-            // buttonOffSMR
-            // 
-            this.buttonOffSMR.Location = new System.Drawing.Point(179, 40);
-            this.buttonOffSMR.Name = "buttonOffSMR";
-            this.buttonOffSMR.Size = new System.Drawing.Size(107, 23);
-            this.buttonOffSMR.TabIndex = 9;
-            this.buttonOffSMR.Text = "Edit Off SMR Email";
-            this.buttonOffSMR.UseVisualStyleBackColor = true;
-            this.buttonOffSMR.Click += new System.EventHandler(this.buttonOffSMR_Click);
-            // 
             // checkBoxAutoUpdates
             // 
             this.checkBoxAutoUpdates.AutoSize = true;
@@ -137,19 +105,26 @@
             this.checkBoxAutoUpdates.Text = "Check for updates on startup?";
             this.checkBoxAutoUpdates.UseVisualStyleBackColor = true;
             // 
+            // labelOffSMR
+            // 
+            this.labelOffSMR.AutoSize = true;
+            this.labelOffSMR.Location = new System.Drawing.Point(13, 47);
+            this.labelOffSMR.Name = "labelOffSMR";
+            this.labelOffSMR.Size = new System.Drawing.Size(100, 13);
+            this.labelOffSMR.TabIndex = 11;
+            this.labelOffSMR.Text = "Edit Off SMR Email:";
+            // 
             // Settings
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(398, 192);
+            this.Controls.Add(this.labelOffSMR);
             this.Controls.Add(this.checkBoxAutoUpdates);
-            this.Controls.Add(this.buttonOffSMR);
             this.Controls.Add(this.linkLabelUpdate);
             this.Controls.Add(this.textBoxEdit);
             this.Controls.Add(this.linkLabelGitHub);
             this.Controls.Add(this.buttonSave);
-            this.Controls.Add(this.buttonSalesReps);
-            this.Controls.Add(this.buttonRegions);
             this.Controls.Add(this.textBoxMapLocation);
             this.Controls.Add(this.labelMapLocation);
             this.MaximizeBox = false;
@@ -164,13 +139,11 @@
         #endregion
         private System.Windows.Forms.Label labelMapLocation;
         private System.Windows.Forms.TextBox textBoxMapLocation;
-        private System.Windows.Forms.Button buttonRegions;
-        private System.Windows.Forms.Button buttonSalesReps;
         private System.Windows.Forms.Button buttonSave;
         private System.Windows.Forms.LinkLabel linkLabelGitHub;
         private System.Windows.Forms.RichTextBox textBoxEdit;
         private System.Windows.Forms.LinkLabel linkLabelUpdate;
-        private System.Windows.Forms.Button buttonOffSMR;
         private System.Windows.Forms.CheckBox checkBoxAutoUpdates;
+        private System.Windows.Forms.Label labelOffSMR;
     }
 }

--- a/SalesMap/Settings.Designer.cs
+++ b/SalesMap/Settings.Designer.cs
@@ -36,6 +36,7 @@
             this.linkLabelUpdate = new System.Windows.Forms.LinkLabel();
             this.checkBoxAutoUpdates = new System.Windows.Forms.CheckBox();
             this.labelOffSMR = new System.Windows.Forms.Label();
+            this.buttonVariables = new System.Windows.Forms.Button();
             this.SuspendLayout();
             // 
             // labelMapLocation
@@ -114,11 +115,22 @@
             this.labelOffSMR.TabIndex = 11;
             this.labelOffSMR.Text = "Edit Off SMR Email:";
             // 
+            // buttonVariables
+            // 
+            this.buttonVariables.Location = new System.Drawing.Point(356, 37);
+            this.buttonVariables.Name = "buttonVariables";
+            this.buttonVariables.Size = new System.Drawing.Size(30, 23);
+            this.buttonVariables.TabIndex = 12;
+            this.buttonVariables.Text = "{V}";
+            this.buttonVariables.UseVisualStyleBackColor = true;
+            this.buttonVariables.Click += new System.EventHandler(this.buttonVariables_Click);
+            // 
             // Settings
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(398, 192);
+            this.Controls.Add(this.buttonVariables);
             this.Controls.Add(this.labelOffSMR);
             this.Controls.Add(this.checkBoxAutoUpdates);
             this.Controls.Add(this.linkLabelUpdate);
@@ -145,5 +157,6 @@
         private System.Windows.Forms.LinkLabel linkLabelUpdate;
         private System.Windows.Forms.CheckBox checkBoxAutoUpdates;
         private System.Windows.Forms.Label labelOffSMR;
+        private System.Windows.Forms.Button buttonVariables;
     }
 }

--- a/SalesMap/Settings.cs
+++ b/SalesMap/Settings.cs
@@ -36,33 +36,19 @@ namespace SalesMap
         private void editOffSMR()
         {
             string offSMRPath = @"C:\Users\" + Environment.UserName + @"\OffSMR.txt";
-            Stream fileStream;
 
             if (File.Exists(offSMRPath))
             {
                 Console.WriteLine("Off SMR file exists");
-                fileStream = File.Open(offSMRPath, FileMode.Open);
+                textBoxEdit.Text = File.ReadAllText(offSMRPath);
             }
             else
             {
                 Console.WriteLine("Off SMR file does not exist");
-                var resourceOffSMR = "SalesMap.OffSMR.txt";
-                var assembly = Assembly.GetExecutingAssembly();
-
-                fileStream = assembly.GetManifestResourceStream(resourceOffSMR);
-            }
-
-            using (StreamReader reader = new StreamReader(fileStream))
-            {
-                string OffSMR = "";
-
-                while (!reader.EndOfStream)
+                using (StreamReader reader = new StreamReader(Assembly.GetExecutingAssembly().GetManifestResourceStream("SalesMap.OffSMR.txt")))
                 {
-                    OffSMR += reader.ReadLine();
-                    OffSMR += Environment.NewLine;
+                    textBoxEdit.Text = reader.ReadToEnd();
                 }
-                Console.WriteLine(OffSMR);
-                textBoxEdit.Text = OffSMR;
             }
         }
 
@@ -78,17 +64,30 @@ namespace SalesMap
                 if (File.Exists(OffSMRPath))
                 {
                     Console.WriteLine("Off SMR file exists");
+                    File.WriteAllText(OffSMRPath, textBoxEdit.Text);
                 }
                 else
                 {
                     Console.WriteLine("Off SMR file does not exist");
-                    using (var stream = File.Create(OffSMRPath))
+
+                    string OffSMRText = "";
+                    using (StreamReader reader = new StreamReader(Assembly.GetExecutingAssembly().GetManifestResourceStream("SalesMap.OffSMR.txt")))
                     {
-                        //Doing this "using bracket" so that IDisposable is implemented afterwards
+                        OffSMRText = reader.ReadToEnd();
+                    }
+
+                    //If the file is unchanged, leave it alone
+                    if (OffSMRText != textBoxEdit.Text)
+                    {
+                        Console.WriteLine("Creating file...");
+                        using (var stream = File.Create(OffSMRPath))
+                        {
+                            //Doing this "using bracket" so that IDisposable is implemented afterwards
+                        }
+
+                        File.WriteAllText(OffSMRPath, textBoxEdit.Text);
                     }
                 }
-
-                File.WriteAllText(OffSMRPath, textBoxEdit.Text);
 
                 this.Close();
         }

--- a/SalesMap/Settings.cs
+++ b/SalesMap/Settings.cs
@@ -127,7 +127,8 @@ namespace SalesMap
 
         private void buttonVariables_Click(object sender, EventArgs e)
         {
-            MessageBox.Show("The available variables for the off SMR email are as follows:\n\n" +
+            MessageBox.Show("You can use the following variables when defining the Off SMR Email (which will get replaced with the appropriate information" +
+                            " when the email is composed):\n\n" +
                             "   - \"{SALESREPNAME}\" ... which will get replaced with the rep's name\n" +
                             "   - \"{SALESREPEMAIL}\" ... which will get replaced with the rep's email\n" +
                             "   - \"{SALESREPPHONE}\" ... which will get replaced with the rep's phone #", "Off SMR EMail Variables");

--- a/SalesMap/Settings.cs
+++ b/SalesMap/Settings.cs
@@ -125,5 +125,13 @@ namespace SalesMap
                 MessageBox.Show("Congrats! You have the most current version!\n\nVersion: " + thisVersion, "Current Version");
             }
         }
+
+        private void buttonVariables_Click(object sender, EventArgs e)
+        {
+            MessageBox.Show("The available variables for the off SMR email are as follows:\n\n" +
+                            "   - \"{SALESREPNAME}\" ... which will get replaced with the rep's name\n" +
+                            "   - \"{SALESREPEMAIL}\" ... which will get replaced with the rep's email\n" +
+                            "   - \"{SALESREPPHONE}\" ... which will get replaced with the rep's phone #", "Off SMR EMail Variables");
+        }
     }
 }

--- a/SalesMap/Settings.cs
+++ b/SalesMap/Settings.cs
@@ -24,6 +24,8 @@ namespace SalesMap
 
             textBoxMapLocation.Text = Properties.Settings.Default.MapFileLocation;
             checkBoxAutoUpdates.Checked = Properties.Settings.Default.AutoCheckUpdate;
+
+            editOffSMR();
         }
 
         private void linkLabelGitHub_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
@@ -31,86 +33,8 @@ namespace SalesMap
             System.Diagnostics.Process.Start("https://github.com/derekantrican/SalesMap/wiki");
         }
 
-        private void buttonRegions_Click(object sender, EventArgs e)
+        private void editOffSMR()
         {
-            buttonRegions.Enabled = false;
-            buttonOffSMR.Enabled = true;
-            buttonSalesReps.Enabled = true;
-
-            string regionPath = @"C:\Users\" + Environment.UserName + @"\Regions.txt";
-            Stream fileStream;
-
-            if (File.Exists(regionPath))
-            {
-                Console.WriteLine("Regions file exists");
-                fileStream = File.Open(regionPath, FileMode.Open);
-            }
-            else
-            {
-                Console.WriteLine("Regions file does not exist");
-                var resourceRegions = "SalesMap.Regions.txt";
-                var assembly = Assembly.GetExecutingAssembly();
-
-                fileStream = assembly.GetManifestResourceStream(resourceRegions);
-            }
-
-            using (StreamReader reader = new StreamReader(fileStream))
-            {
-                string Regions = "";
-
-                while (!reader.EndOfStream)
-                {
-                    Regions += reader.ReadLine();
-                    Regions += Environment.NewLine;
-                }
-                Console.WriteLine(Regions);
-                textBoxEdit.Text = Regions;
-            }
-        }
-
-        private void buttonSalesReps_Click(object sender, EventArgs e)
-        {
-            buttonSalesReps.Enabled = false;
-            buttonOffSMR.Enabled = true;
-            buttonRegions.Enabled = true;
-
-            string salesPath = @"C:\Users\" + Environment.UserName + @"\SalesReps.txt";
-            Stream fileStream;
-
-            if (File.Exists(salesPath))
-            {
-                Console.WriteLine("Sales file exists");
-                fileStream = File.Open(salesPath, FileMode.Open);
-            }
-            else
-            {
-                Console.WriteLine("Sales file does not exist");
-                var resourceSales = "SalesMap.SalesReps.txt";
-                var assembly = Assembly.GetExecutingAssembly();
-
-                fileStream = assembly.GetManifestResourceStream(resourceSales);
-            }
-
-            using (StreamReader reader = new StreamReader(fileStream))
-            {
-                string SalesReps = "";
-
-                while (!reader.EndOfStream)
-                {
-                    SalesReps += reader.ReadLine();
-                    SalesReps += Environment.NewLine;
-                }
-                Console.WriteLine(SalesReps);
-                textBoxEdit.Text = SalesReps;
-            }
-        }
-
-        private void buttonOffSMR_Click(object sender, EventArgs e)
-        {
-            buttonOffSMR.Enabled = false;
-            buttonSalesReps.Enabled = true;
-            buttonRegions.Enabled = true;
-
             string offSMRPath = @"C:\Users\" + Environment.UserName + @"\OffSMR.txt";
             Stream fileStream;
 
@@ -148,64 +72,6 @@ namespace SalesMap
             Properties.Settings.Default.AutoCheckUpdate = checkBoxAutoUpdates.Checked;
             Properties.Settings.Default.Save();
 
-            bool restart = false;
-
-            if (buttonRegions.Enabled == false || buttonSalesReps.Enabled == false || buttonOffSMR.Enabled == false)
-            {
-                if (MessageBox.Show("In order for changes to the Regions or Sales Rep files to take effect, you must restart the program. \n\nRestart now?",
-                                    "Restart Required", MessageBoxButtons.YesNo, MessageBoxIcon.Exclamation) == DialogResult.Yes)
-                {
-                    restart = true;
-                }
-                else
-                {
-                    MessageBox.Show("Your changes will not be saved");
-                    return;
-                }
-            }
-
-            if (buttonRegions.Enabled == false) //We are editing Regions.txt
-            {
-                //WRITE TO REGIONS FILE
-                string regionPath = @"C:\Users\" + Environment.UserName + @"\Regions.txt";
-
-                if (File.Exists(regionPath))
-                {
-                    Console.WriteLine("Regions file exists");
-                }
-                else
-                {
-                    Console.WriteLine("Regions file does not exist");
-                    using (var stream = File.Create(regionPath))
-                    {
-                        //Doing this "using bracket" so that IDisposable is implemented afterwards
-                    }
-                }
-
-                File.WriteAllText(regionPath, textBoxEdit.Text);
-            }
-            else if(buttonSalesReps.Enabled == false) //We are editing SalesReps.txt
-            {
-                //WRITE TO SALES REP FILE
-                string salesPath = @"C:\Users\" + Environment.UserName + @"\SalesReps.txt";
-
-                if (File.Exists(salesPath))
-                {
-                    Console.WriteLine("Sales file exists");
-                }
-                else
-                {
-                    Console.WriteLine("Sales file does not exist");
-                    using (var stream = File.Create(salesPath))
-                    {
-                        //Doing this "using bracket" so that IDisposable is implemented afterwards
-                    }
-                }
-
-                File.WriteAllText(salesPath, textBoxEdit.Text);
-            }
-            else if(buttonOffSMR.Enabled == false) //We are editing OffSMR.txt
-            {
                 //WRITE TO OFF SMR FILE
                 string OffSMRPath = @"C:\Users\" + Environment.UserName + @"\OffSMR.txt";
 
@@ -223,24 +89,8 @@ namespace SalesMap
                 }
 
                 File.WriteAllText(OffSMRPath, textBoxEdit.Text);
-            }
 
-            //SettingsUpdated?.Invoke();
-
-            if (restart)
-            {
-                ProcessStartInfo Info = new ProcessStartInfo();
-                Info.Arguments = "/C ping 127.0.0.1 -n 2 && \"" + Application.ExecutablePath + "\"";
-                Info.WindowStyle = ProcessWindowStyle.Hidden;
-                Info.CreateNoWindow = true;
-                Info.FileName = "cmd.exe";
-                Process.Start(Info);
-                Application.Exit();
-            }
-            else
-            {
                 this.Close();
-            }
         }
 
         private void linkLabelUpdate_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)


### PR DESCRIPTION
Adding the ability to automatically update the database. If the checkbox for "Check for updates on startup" is checked (which it is by default), then the databases will automatically be checked for updates on startup. This removes the ability (and, therefore, the burden) for the user to do it themselves- although there is still a workaround to achieve this if a user really wants to.

Because of this change, the main changes to the UI are in the settings screen where there used to be 3 buttons ("Edit Regions", "Edit Sales Reps", and "Edit Off SMR Email"). Now there are no buttons there and the textbox is solely used to edit the Off SMR canned email. There is also now a button there  as a "help dialog" to show the user what variables can be used in the Off SMR canned email definition.
